### PR TITLE
reasoning: Add an actual introduction

### DIFF
--- a/reasoning.md
+++ b/reasoning.md
@@ -6,7 +6,10 @@ description: Reasoning behind the Independent Systems Architecture (ISA) princip
 
 ## Introduction
 
-Each of the principles has a reasoning behind it:
+ISA (Independent Systems Architecture) is a collection of best practices.
+This page explains the reasoning behind each of the principles it comprises.
+
+## Reasoning
 
 1. *Modularization* has been recognized as an important tool for handling
      large and complex software systems for a very long time. Using


### PR DESCRIPTION
The reasoning page lists the reasons under an "Introduction" heading.
The index and non-principles pages both feature such a heading, but only with a short, well, _introduction_ under it, and a separate heading for the meat of the page.
This change adds an introductory paragraph and a separate subheading for the reasoning list.