### PR TITLE
title: Unify title styles

### DIFF
--- a/discussion.html
+++ b/discussion.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "ISA - Independent Systems Architecture - Discussion"
+title: "ISA: Independent Systems Architecture - Discussion"
 description: Discussion about Independent Systems Architecture (ISA)
 ---
 

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "ISA - Independent Systems Architecture- FAQ"
+title: "ISA: Independent Systems Architecture - FAQ"
 description: Frequently asked questions (FAQ) about the Independent Systems Architecture (ISA)
 ---
 

--- a/non-principles.md
+++ b/non-principles.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "ISA: Independent Systems Architecture: Non Principles"
+title: "ISA: Independent Systems Architecture - Non Principles"
 description: Independent Systems Architecture (ISA) leaves some principles out - why?
 ---
 


### PR DESCRIPTION
The titles of some pages use inconsistent punctuation.
This changes imposes the format:
ISA: Independent Systems Architecture - Subpage